### PR TITLE
Update github and email for Nicholas Kovacs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,5 +97,5 @@ This repository constitutes a work of the United States Government and is not su
 ## Points of contact
 
 Maintainer Nicole Paterson (CDC) @patersonnicole <qxa4@cdc.gov>
-Developer Nicholas Kovacs (CDC) @kovacsnicholas <pgv8@cdc.gov>
+Developer Nicholas Kovacs (CDC) @nicholasakovacs <nattila.kovacs@gmail.com>
 Developer Brian Mann (CDC) @mannbrian <ytw4@cdc.gov>


### PR DESCRIPTION
Nick's github userid was wrong and this is his proper handle. Also switched to his gmail as his cdc doesn't work any longer.

Simple PR to fix Nick's github.